### PR TITLE
PythonCallingDocker: More modularity on volume creations

### DIFF
--- a/Computations/3DTiles/LyonTemporal/PythonCallingDocker/Readme.md
+++ b/Computations/3DTiles/LyonTemporal/PythonCallingDocker/Readme.md
@@ -26,7 +26,7 @@ If you wan to run unit tests:
 
 FIXME: the rest is under construction
 
-## Running the worflow
+## Running the workflow
 
 ### Manual step by step run
 
@@ -49,7 +49,7 @@ The resulting file hierarchy will be located in the `junk` sub-directory.
 
 ## Issues
 ### Convert the configuration files to YAML
-Merge the three configuration files in a singe one using a YAML syntax.
+Merge the three configuration files in a single one using a YAML syntax.
 Extract the loading of that file (Docker3DCityDBServer::load_config_file)
 from the Docker3DCityDBServer class and pass the loaded dictionnary to
 the Docker3DCityDBServer::__init__ constructor.

--- a/Computations/3DTiles/LyonTemporal/PythonCallingDocker/Readme.md
+++ b/Computations/3DTiles/LyonTemporal/PythonCallingDocker/Readme.md
@@ -36,6 +36,7 @@ FIXME: the rest is under construction
 (venv)$ python docker_split_buildings.py
 (venv)$ python docker_strip_attributes.py
 (venv)$ python docker_extract_building_dates.py
+(venv)$ python docker_3dcitydb_server.py
 ```
 The resulting file hierarchy will be located in the `junk` sub-directory.
 

--- a/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_3dcitydb_server.py
+++ b/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_3dcitydb_server.py
@@ -87,8 +87,7 @@ class Docker3DCityDBServer(DockerHelperService):
         Overloads the run method of DockerHelperService.
         :return:
         """
-        absolute_path_output_dir = os.path.join(os.getcwd(), demo.output_dir, '/postgres-data/')
-        print(absolute_path_output_dir)
+        absolute_path_output_dir = os.path.join(os.getcwd(), demo.output_dir) + '/postgres-data'
         self.add_volume(absolute_path_output_dir, '/var/lib/postgresql/data', 'rw')
         super().run()
 

--- a/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_3dcitydb_server.py
+++ b/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_3dcitydb_server.py
@@ -83,7 +83,7 @@ class Docker3DCityDBServer(DockerHelperService):
         return None
 
     def run(self):
-        self.add_volume('./docker-data/postgres-data/', '/var/lib/postgresql/data', 'rw')
+        self.add_volume('/Output/postgres-data/', '/var/lib/postgresql/data', 'rw')
         super().run()
 
 

--- a/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_3dcitydb_server.py
+++ b/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_3dcitydb_server.py
@@ -83,7 +83,13 @@ class Docker3DCityDBServer(DockerHelperService):
         return None
 
     def run(self):
-        self.add_volume('/Output/postgres-data/', '/var/lib/postgresql/data', 'rw')
+        """
+        Overloads the run method of DockerHelperService.
+        :return:
+        """
+        absolute_path_output_dir = os.path.join(os.getcwd(), demo.output_dir, '/postgres-data/')
+        print(absolute_path_output_dir)
+        self.add_volume(absolute_path_output_dir, '/var/lib/postgresql/data', 'rw')
         super().run()
 
 

--- a/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_3dcitydb_server.py
+++ b/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_3dcitydb_server.py
@@ -82,6 +82,10 @@ class Docker3DCityDBServer(DockerHelperService):
         # by default in the Dockerfile
         return None
 
+    def run(self):
+        self.add_volume('./docker-data/postgres-data/', '/var/lib/postgresql/data', 'rw')
+        super().run()
+
 
 if __name__ == '__main__':
     logger = logging.getLogger(__name__)

--- a/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_helper.py
+++ b/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_helper.py
@@ -13,7 +13,6 @@ class DockerHelperBase(ABC):
         # The name of the image to build or to pull
         self.image_name = image_name
         self.container_name = None
-        self.container_name = None
         self.mounted_input_dir = os.getcwd()
         self.mounted_output_dir = os.getcwd()
         # Some containers (like 3DUse) provide multiple commands each of

--- a/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_helper.py
+++ b/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_helper.py
@@ -167,8 +167,8 @@ class DockerHelperBase(ABC):
 
 
 class DockerHelperService(DockerHelperBase):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, image_name):
+        super().__init__(image_name)
         self.ports = None
 
     """
@@ -196,7 +196,7 @@ class DockerHelperTask(DockerHelperBase):
     def run(self):
         # Set input and output volumes
         # Tasks volumes are set in this class with the following convention:
-        # input files are located 
+        # input files are located
         self.add_volume(self.mounted_input_dir, '/Input', 'rw')
         if not self.mounted_input_dir == self.mounted_output_dir:
             # When mounting the same directory twice (which is the case when

--- a/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_helper.py
+++ b/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_helper.py
@@ -21,12 +21,10 @@ class DockerHelperBase(ABC):
         self.working_dir = None
         self.volumes = dict()
         self.environment = None   # Docker run environment variables
-
-        self.ports = None  # Specific to derived class DockerHelperService
+        self.run_arguments = None  # The arguments handled over to the run()
 
         self.__client = None  # The name for the docker client (read server)
         self.__container = None
-        self.__run_arguments = None  # The arguments handled over to the run()
 
         self.assert_server_is_active()
 
@@ -108,11 +106,13 @@ class DockerHelperBase(ABC):
 
     def add_volume(self, host_volume, inside_docker_volume, mode):
         """
-        :param host_volume: The host path or the volume name (that must have been created before
-        with docker volume create) to bind the data to.
-        :param inside_docker_volume: The path to mount the volume inside the container.
-        :param mode: Volume access mode which is either 'rw' for 'read write'
-        or 'ro' for read-only.
+        :param host_volume: The host path (must be absolute) or
+        the volume name (must have been created earlier with
+        docker volume create) to bind the data to.
+        :param inside_docker_volume: The path to mount
+        the volume inside the container.
+        :param mode: Volume access mode which is either
+        'rw' for 'read write' or 'ro' for read-only.
         """
         self.volumes[host_volume] = {'bind': inside_docker_volume, 'mode': mode}
 
@@ -120,12 +120,8 @@ class DockerHelperBase(ABC):
     def get_command(self):
         print("WTF")
 
-    def run(self):
-        """
-        Prepare the information required to launch the container and run it
-        (always in a detached mode, for technical reasons).
-        """
-        arguments = dict(
+    def set_run_arguments(self):
+        self.run_arguments = dict(
             # command=["/bin/sh", "-c", "ls /Input /Output"],      # for debug
             command=self.get_command(),
             volumes=self.volumes,
@@ -143,18 +139,21 @@ class DockerHelperBase(ABC):
                 logging.error(f'A container named {self.container_name} '
                               'already exists. Exiting.')
                 sys.exit(1)
-            arguments['name'] = self.container_name
+            self.run_arguments['name'] = self.container_name
 
-        arguments['environment'] = self.environment
+        if self.environment:
+            self.run_arguments['environment'] = self.environment
         if self.working_dir:
-            arguments['working_dir'] = self.working_dir
-        if self.ports:
-            arguments['ports'] = self.ports
-        self.__run_arguments = arguments
+            self.run_arguments['working_dir'] = self.working_dir
 
+    def run(self):
+        """
+        Prepare the information required to launch the container and run it
+        (always in a detached mode, for technical reasons).
+        """
         self.__container = self.__client.containers.run(
             self.image_name,
-            **self.__run_arguments)
+            **self.run_arguments)
 
     def retrieve_output_and_errors(self):
         out = self.__container.logs(stdout=True, stderr=False)
@@ -168,6 +167,10 @@ class DockerHelperBase(ABC):
 
 
 class DockerHelperService(DockerHelperBase):
+    def __init__(self):
+        super().__init__()
+        self.ports = None
+
     """
     Have the container run a server and serve until explicit termination
     is required.
@@ -176,6 +179,12 @@ class DockerHelperService(DockerHelperBase):
         self.get_container().stop()
         self.retrieve_output_and_errors()
         self.get_container().remove()
+
+    def run(self):
+        self.set_run_arguments()
+        if self.ports:
+            self.run_arguments['ports'] = self.ports
+        super().run()
 
 
 class DockerHelperTask(DockerHelperBase):
@@ -186,6 +195,8 @@ class DockerHelperTask(DockerHelperBase):
 
     def run(self):
         # Set input and output volumes
+        # Tasks volumes are set in this class with the following convention:
+        # input files are located 
         self.add_volume(self.mounted_input_dir, '/Input', 'rw')
         if not self.mounted_input_dir == self.mounted_output_dir:
             # When mounting the same directory twice (which is the case when
@@ -196,6 +207,7 @@ class DockerHelperTask(DockerHelperBase):
             # to place its output in the /Input mounted point (because in this
             # /Output is (equal to) /Input.
             self.add_volume(self.mounted_output_dir, '/Output', 'rw')
+        self.set_run_arguments()
         super().run()
         self.get_container().wait()
         self.retrieve_output_and_errors()


### PR DESCRIPTION
* Volumes creation have been moved from `DockerHelper` to the `DockerHelperService` and `DockerHelperTask` child classes.
* `DockerHelperService` and `DockerHelperTask` can add run arguments.
* The content of the 3D City DB database is now stored in '<output_dir>/postgres-data/