### PR TITLE
Python docker - 3dcitydb importer-exporter

### DIFF
--- a/Computations/3DTiles/LyonTemporal/Docker/3DCityDBImpExp-DockerContext/Dockerfile
+++ b/Computations/3DTiles/LyonTemporal/Docker/3DCityDBImpExp-DockerContext/Dockerfile
@@ -26,8 +26,14 @@ RUN set -x && \
 # Clone 3DCityDB
 RUN set -x && \
   mkdir -p build_tmp && \
-  git clone -b "${IMPEXP_VERSION}" --depth 1 https://github.com/3dcitydb/importer-exporter.git build_tmp && \
-  git checkout 8fddd30edbe2e21b37114182af33edc1379bc945
+  git clone -b "${IMPEXP_VERSION}" --depth 1 https://github.com/3dcitydb/importer-exporter.git build_tmp
+
+# Checkout on a specific sha1 that we know to be working with the -shell option
+# FIXME: the checkout does not work when running the docker file but does
+# when running the commands of this docker in a terminal....
+#RUN set -x && \
+#  cd build_tmp && \
+#  git checkout 8fddd30edbe2e21b37114182af33edc1379bc945
 
 # Build ImpExp
 RUN set -x && \

--- a/Computations/3DTiles/LyonTemporal/Docker/3DCityDBImpExp-DockerContext/Dockerfile
+++ b/Computations/3DTiles/LyonTemporal/Docker/3DCityDBImpExp-DockerContext/Dockerfile
@@ -1,0 +1,62 @@
+# 3DCityDB Importer/Exporter Dockerfile #######################################
+#   Official website    https://www.3dcitydb.net
+#   GitHub              https://github.com/3dcitydb/importer-exporter
+###############################################################################
+# Base image
+ARG baseimage_tag='11'
+FROM openjdk:${baseimage_tag}
+
+# Labels ######################################################################
+LABEL maintainer="Bruno Willenborg"
+LABEL maintainer.email="b.willenborg(at)tum.de"
+LABEL maintainer.organization="Chair of Geoinformatics, Technical University of Munich (TUM)"
+LABEL source.repo="https://github.com/tum-gis/3dcitydb-importer-exporter-docker"
+
+# Setup PostGIS and 3DCityDB ##################################################
+ARG impexp_version='master'
+ENV IMPEXP_VERSION=${impexp_version}
+
+ARG BUILD_PACKAGES='git'
+
+# Setup build and runtime deps
+RUN set -x && \
+  apt-get update && \
+  apt-get install -y --no-install-recommends $BUILD_PACKAGES
+
+# Clone 3DCityDB
+RUN set -x && \
+  mkdir -p build_tmp && \
+  git clone -b "${IMPEXP_VERSION}" --depth 1 https://github.com/3dcitydb/importer-exporter.git build_tmp && \
+  git checkout 8fddd30edbe2e21b37114182af33edc1379bc945
+
+# Build ImpExp
+RUN set -x && \
+  cd build_tmp && \
+  chmod u+x ./gradlew && \
+  ./gradlew installDist
+
+# Move dist
+RUN set -x && \
+  ls -lA . && \
+  mv /build_tmp/impexp-client/build/install/3DCityDB-Importer-Exporter/ /impexp && \
+  ls -lA /impexp
+
+# create share folder structure
+RUN set -x && \
+  mkdir -p /share/config /share/data
+
+# Cleanup
+RUN set -x && \
+  rm -rf build_tmp && \
+  ls -lA && \
+  apt-get purge -y --auto-remove $BUILD_PACKAGES && \
+  rm -rf /var/lib/apt/lists/*
+
+# Copy entrypoint script
+COPY impexp.sh /impexp/bin
+
+RUN set -x && \
+  chmod -v u+x /impexp/bin/* /impexp/contribs/collada2gltf/COLLADA2GLTF*linux/COLLADA2GLTF*
+
+WORKDIR /impexp
+ENTRYPOINT [ "./bin/impexp.sh"]

--- a/Computations/3DTiles/LyonTemporal/Docker/3DCityDBImpExp-DockerContext/Readme.md
+++ b/Computations/3DTiles/LyonTemporal/Docker/3DCityDBImpExp-DockerContext/Readme.md
@@ -1,0 +1,55 @@
+This docker context is a patch from the
+[3dcitydb-importer-exporter-docker](https://github.com/tum-gis/3dcitydb-importer-exporter-docker),
+sha1 [c232ebd750944136e6380ff7cee1330c42bd3cd4](https://github.com/tum-gis/3dcitydb-importer-exporter-docker/tree/c232ebd750944136e6380ff7cee1330c42bd3cd4).
+
+
+### Technical details:
+
+It seems that since version 4.2.2, 
+[3DcityDB-Importer-Exporter](https://github.com/3dcitydb/importer-exporter) 
+does not support the `-shell` CLI option anymore (which allows to run it without
+the GUI, and which we need in our pipelines). In addition, version 4.2.2
+cannot be installed anymore due to unsatisfied dependencies (osgeotools lib
+in this case). Therefore, we modified the 
+[3dcitydb-importer-exporter-docker](https://github.com/tum-gis/3dcitydb-importer-exporter-docker)
+ to checkout a specific version of the 3DcityDB-Importer-Exporter  
+(in this case, the current master version, sha1 
+[8fddd30edbe2e21b37114182af33edc1379bc945](https://github.com/3dcitydb/importer-exporter/tree/8fddd30edbe2e21b37114182af33edc1379bc945)).
+
+We made the following modification to the DockerFile (git diff output):
+
+````
+@@ -26,7 +26,8 @@ RUN set -x && \
+ # Clone 3DCityDB
+ RUN set -x && \
+   mkdir -p build_tmp && \
+-  git clone -b "${IMPEXP_VERSION}" --depth 1 https://github.com/3dcitydb/importer-exporter.git build_tmp
++  git clone -b "${IMPEXP_VERSION}" --depth 1 https://github.com/3dcitydb/importer-exporter.git build_tmp && \
++  git checkout 8fddd30edbe2e21b37114182af33edc1379bc945
+ 
+ # Build ImpExp
+ RUN set -x && \
+
+````
+
+We also updated the `impexp.sh` script to call the `impexp` binary with the
+ instead of the `3DCityDB-Importer-Exporter` which does not
+ support the `-shell` option (see the git diff bellow):
+
+````
+@@ -25,7 +25,7 @@ cat <<EOF
+ EOF
+ 
+ # Print version info
+-./bin/3DCityDB-Importer-Exporter -shell -version
++./bin/impexp  -shell -version
+  
+ # Print cmd line passed to container
+ printf "Following command line parameters are passed to the 3DCityDB ImporterExporter:\n"
+@@ -33,4 +33,4 @@ printf "\n\t"
+ echo "-shell $@"
+ echo
+ 
+-./bin/3DCityDB-Importer-Exporter -shell "$@"
++./bin/impexp  -shell "$@"
+````

--- a/Computations/3DTiles/LyonTemporal/Docker/3DCityDBImpExp-DockerContext/impexp.sh
+++ b/Computations/3DTiles/LyonTemporal/Docker/3DCityDBImpExp-DockerContext/impexp.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Print commands and their arguments as they are executed
+set -e;
+
+# echo version info and maintainer
+cat <<EOF
+
+
+# 3DCityDB ImporterExporter Docker #############################################
+################################################################################
+#
+#   3DCityDB ImporterExporter version $IMPEXP_VERSION
+#     version info    https://github.com/3dcitydb/3dcitydb/tree/${IMPEXP_VERSION}
+#
+# Maintainer -------------------------------------------------------------------
+#   Bruno Willenborg
+#   Chair of Geoinformatics
+#   Department of Civil, Geo and Environmental Engineering
+#   Technical University of Munich (TUM)
+#   b.willenborg(at)tum.de
+#
+################################################################################
+
+EOF
+
+# Print version info
+./bin/impexp  -shell -version
+ 
+# Print cmd line passed to container
+printf "Following command line parameters are passed to the 3DCityDB ImporterExporter:\n"
+printf "\n\t"
+echo "-shell $@"
+echo
+
+./bin/impexp  -shell "$@"

--- a/Computations/3DTiles/LyonTemporal/Docker/3DCityDBImpExp-DockerContext/impexp.sh
+++ b/Computations/3DTiles/LyonTemporal/Docker/3DCityDBImpExp-DockerContext/impexp.sh
@@ -25,7 +25,7 @@ cat <<EOF
 EOF
 
 # Print version info
-./bin/impexp  -shell -version
+./bin/impexp -shell -version
  
 # Print cmd line passed to container
 printf "Following command line parameters are passed to the 3DCityDB ImporterExporter:\n"
@@ -33,4 +33,4 @@ printf "\n\t"
 echo "-shell $@"
 echo
 
-./bin/impexp  -shell "$@"
+./bin/impexp -shell "$@"

--- a/Computations/3DTiles/LyonTemporal/PythonCallingDocker/Readme.md
+++ b/Computations/3DTiles/LyonTemporal/PythonCallingDocker/Readme.md
@@ -37,6 +37,7 @@ FIXME: the rest is under construction
 (venv)$ python docker_strip_attributes.py
 (venv)$ python docker_extract_building_dates.py
 (venv)$ python docker_3dcitydb_server.py
+(venv)$ python docker_load_3dcitydb.py
 ```
 The resulting file hierarchy will be located in the `junk` sub-directory.
 

--- a/Computations/3DTiles/LyonTemporal/PythonCallingDocker/demo_strip_attributes.py
+++ b/Computations/3DTiles/LyonTemporal/PythonCallingDocker/demo_strip_attributes.py
@@ -3,22 +3,34 @@ import os
 import sys
 import demo_configuration
 
-
+# FIXME: is that the inputsOutputs for one file or for multiple files ? Since
+#  the strip process treats only one file at a time, it should be for one
+#  file ? Currently this class seems to mix those approaches (for one file or
+#  for multiple files)
 class StripInputsOutputs:
     """
     A utility class gathering the conventional names, relative to this demo,
     used by the strip algorithms for designating its input/output directories
     and filenames
     """
+    # FIXME: add several output options (e.g. using an enum) :
+    #  next_to_imput_dir,
     def __init__(self,
+                 input_dir=demo_configuration.output_dir,
                  output_dir=demo_configuration.output_dir,
                  vintages=demo_configuration.vintages,
                  boroughs=demo_configuration.boroughs):
+        self.input_dir = input_dir
         self.output_dir = output_dir
+        # FIXME: these two arguments may be directly used from
+        #  demo_configuration since we import it ?
         self.vintages = vintages
         self.boroughs = boroughs
 
-    def get_output_dir(self, vintage, create=True):
+    # FIXME: ambiguous name since it does not returns self.output_dir but a
+    #  so called "resulting dir". Can we reduce the entropy and avoid having
+    #  to much input/output files/folders?
+    def get_output_dir(self, vintage, borough, create=True):
         """
         :param vintage: a integer or string designating a year
         :param create: when the proposed output directory does not already
@@ -27,13 +39,16 @@ class StripInputsOutputs:
         """
         if isinstance(vintage, int):
             vintage = str(vintage)
-        strip_dir = 'LYON_' + vintage + '_Splitted_Stripped'
+        strip_dir = borough + vintage
         result_dir = os.path.join(self.output_dir, strip_dir)
         if create and not os.path.isdir(result_dir):
             logging.info(f'Creating strip output directory {result_dir}.')
             os.mkdir(result_dir)
         return result_dir
 
+    # FIXME: add the possibility to pass a (list of) vintage and/or a (
+    #  list of) borough to allow
+    #  to get all filenames or only for a vintage and/or borough
     def get_resulting_files_basenames(self):
         """
         :return: the list of the basename (no directory) filenames that the

--- a/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_3dcitydb_server.py
+++ b/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_3dcitydb_server.py
@@ -86,13 +86,12 @@ class Docker3DCityDBServer(DockerHelperPull, DockerHelperService):
         """
         absolute_path_output_dir = os.path.join(os.getcwd(),
                                                 demo.output_dir,
-                                                'postgres-data')
+                                                'postgres-data',
+                                                self.container_name)
         if not os.path.isdir(absolute_path_output_dir):
             logging.info('Creating local mount-point directory '
                          f'{absolute_path_output_dir}')
             os.mkdir(absolute_path_output_dir)
-        # FIXME: the class user must be able to specify the local directory
-        # (we need to separate the vintage databases).
 
         self.add_volume(absolute_path_output_dir,
                         '/var/lib/postgresql/data',
@@ -109,6 +108,7 @@ if __name__ == '__main__':
         data_base = Docker3DCityDBServer()
         data_base.set_config_file('DBConfig' + str(vintage) + '.yml')
         data_base.load_config_file()
+        data_base.set_database_name('')
         data_base.run()
         active_databases.append(data_base)
 

--- a/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_3duse.py
+++ b/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_3duse.py
@@ -11,3 +11,17 @@ class Docker3DUse(DockerHelperBuild, DockerHelperTask):
                                    'Docker',
                                    '3DUse-DockerContext')
         self.build(context_dir)
+
+    def run(self):
+        # Set input and output volumes
+        self.add_volume(self.mounted_input_dir, '/Input', 'rw')
+        if not self.mounted_input_dir == self.mounted_output_dir:
+            # When mounting the same directory twice (which is the case when
+            # the input and output directory are the same) then containers.run()
+            # raises a docker.errors.ContainerError. Hence we only mount the
+            # /Output volume when they both differ. Note that when this
+            # happens the command in the derived class must be altered in order
+            # to place its output in the /Input mounted point (because in this
+            # /Output is (equal to) /Input.
+            self.add_volume(self.mounted_output_dir, '/Output', 'rw')
+        super().run()

--- a/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_helper.py
+++ b/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_helper.py
@@ -238,16 +238,20 @@ class DockerHelperTask(DockerHelperContainer):
         # Set input and output volumes
         # Tasks volumes are set in this class with the following convention:
         # input files are located
-        self.add_volume(self.mounted_input_dir, '/Input', 'rw')
-        if not self.mounted_input_dir == self.mounted_output_dir:
-            # When mounting the same directory twice (which is the case when
-            # the input and output directory are the same) then containers.run()
-            # raises a docker.errors.ContainerError. Hence we only mount the
-            # /Output volume when they both differ. Note that when this
-            # happens the command in the derived class must be altered in order
-            # to place its output in the /Input mounted point (because in this
-            # /Output is (equal to) /Input.
-            self.add_volume(self.mounted_output_dir, '/Output', 'rw')
+        # FIXME: This should not be done in this class but should be the
+        #  responsibility of inheriting classes instead since in some cases, it
+        #  is not the volumes we want to mount (e.g. for DockerLoad3DCityDB)
+        #  Note: removing it makes the dockerload3dcitydb work
+        # self.add_volume(self.mounted_input_dir, '/Input', 'rw')
+        # if not self.mounted_input_dir == self.mounted_output_dir:
+        #     # When mounting the same directory twice (which is the case when
+        #     # the input and output directory are the same) then containers.run()
+        #     # raises a docker.errors.ContainerError. Hence we only mount the
+        #     # /Output volume when they both differ. Note that when this
+        #     # happens the command in the derived class must be altered in order
+        #     # to place its output in the /Input mounted point (because in this
+        #     # /Output is (equal to) /Input.
+        #     self.add_volume(self.mounted_output_dir, '/Output', 'rw')
         self.set_run_arguments()
         super().run()
         self.get_container().wait()

--- a/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_helper.py
+++ b/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_helper.py
@@ -235,23 +235,6 @@ class DockerHelperTask(DockerHelperContainer):
     computation is done, terminate the container.
     """
     def run(self):
-        # Set input and output volumes
-        # Tasks volumes are set in this class with the following convention:
-        # input files are located
-        # FIXME: This should not be done in this class but should be the
-        #  responsibility of inheriting classes instead since in some cases, it
-        #  is not the volumes we want to mount (e.g. for DockerLoad3DCityDB)
-        #  Note: removing it makes the dockerload3dcitydb work
-        # self.add_volume(self.mounted_input_dir, '/Input', 'rw')
-        # if not self.mounted_input_dir == self.mounted_output_dir:
-        #     # When mounting the same directory twice (which is the case when
-        #     # the input and output directory are the same) then containers.run()
-        #     # raises a docker.errors.ContainerError. Hence we only mount the
-        #     # /Output volume when they both differ. Note that when this
-        #     # happens the command in the derived class must be altered in order
-        #     # to place its output in the /Input mounted point (because in this
-        #     # /Output is (equal to) /Input.
-        #     self.add_volume(self.mounted_output_dir, '/Output', 'rw')
         self.set_run_arguments()
         super().run()
         self.get_container().wait()

--- a/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_load_database.py
+++ b/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_load_database.py
@@ -3,8 +3,9 @@ import sys
 import logging
 import git
 from docker_helper import DockerHelperBuild, DockerHelperTask
+from docker_3dcitydb_server import Docker3DCityDBServer
 import demo_strip_attributes
-import demo_configuration
+import demo_configuration as demo
 
 
 class DockerLoadDatabase(DockerHelperBuild, DockerHelperTask):
@@ -100,7 +101,6 @@ def import_files(configuration_file, input_filenames):
 
 
 if __name__ == '__main__':
-    from docker_3dcitydb_server import Docker3DCityDBServer
 
     logger = logging.getLogger(__name__)
     logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
@@ -110,23 +110,23 @@ if __name__ == '__main__':
     # cannot access it in this context
 
     logging.info('Stage 1: starting databases.')
-    if False:
-        active_databases = list()
-        for vintage in demo.vintages:
-            data_base = Docker3DCityDBServer()
-            data_base.set_config_file('DBConfig' + str(vintage) + '.yml')
-            data_base.load_config_file()
-            data_base.run()
-            active_databases.append(data_base)
-        logging.info('Stage 1: done.')
+
+    active_databases = list()
+    for vintage in demo.vintages:
+        data_base = Docker3DCityDBServer()
+        data_base.set_config_file('DBConfig' + str(vintage) + '.yml')
+        data_base.load_config_file()
+        data_base.run()
+        active_databases.append(data_base)
+    logging.info('Stage 1: done.')
 
     logging.info(f'Stage 2: importing files to databases.')
-    for vintage in demo_configuration.vintages:
+    for vintage in demo.vintages:
         inputs = list()
         strip = demo_strip_attributes.StripInputsOutputs(
-            output_dir=demo_configuration.output_dir,
+            output_dir=demo.output_dir,
             vintages=[vintage],
-            boroughs=demo_configuration.boroughs)
+            boroughs=demo.boroughs)
 
         for file in strip.get_resulting_files_basenames():
             relative_filename = os.path.join(

--- a/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_strip_attributes.py
+++ b/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_strip_attributes.py
@@ -53,6 +53,20 @@ class DockerStripAttributes(DockerHelperBuild, DockerHelperTask):
         command += self.output_filename + ' '
         return command
 
+    def run(self):
+        # Set input and output volumes
+        self.add_volume(self.mounted_input_dir, '/Input', 'rw')
+        if not self.mounted_input_dir == self.mounted_output_dir:
+            # When mounting the same directory twice (which is the case when
+            # the input and output directory are the same) then containers.run()
+            # raises a docker.errors.ContainerError. Hence we only mount the
+            # /Output volume when they both differ. Note that when this
+            # happens the command in the derived class must be altered in order
+            # to place its output in the /Input mounted point (because in this
+            # /Output is (equal to) /Input.
+            self.add_volume(self.mounted_output_dir, '/Output', 'rw')
+        super().run()
+
 
 if __name__ == '__main__':
     logger = logging.getLogger(__name__)

--- a/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_strip_attributes.py
+++ b/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_strip_attributes.py
@@ -76,5 +76,7 @@ if __name__ == '__main__':
                 DockerStripAttributes(),
                 input_dir=os.path.dirname(filename),
                 input_filename=os.path.basename(filename),
-                output_dir=strip.get_output_dir(vintage))
+                output_dir=os.path.dirname(filename))
+            # FIXME: we should probably use strip.get_output_dir(vintage,
+            #  borough) for the output_dir.
 


### PR DESCRIPTION
This PR fixes the 3dcitydb importer-exporter in the PythonCallingDocker pipeline. The StripInputsOutputs class is not used anymore for now but it should be in the future (after making some design choices and fixing some issues; see the FIXMEs in the code).