### PR TITLE
Generate 3DCityDB importer exporter config files with jinja2

### DIFF
--- a/Computations/3DTiles/LyonTemporal/PythonCallingDocker/DBConfig2009.yml
+++ b/Computations/3DTiles/LyonTemporal/PythonCallingDocker/DBConfig2009.yml
@@ -1,6 +1,0 @@
-PG_HOST: 192.168.1.51
-PG_PORT: 5432
-PG_NAME: citydb-full_lyon-2009
-PG_USER: postgres
-PG_PASSWORD: postgres
-PG_VINTAGE: 2009

--- a/Computations/3DTiles/LyonTemporal/PythonCallingDocker/DBConfig2012.yml
+++ b/Computations/3DTiles/LyonTemporal/PythonCallingDocker/DBConfig2012.yml
@@ -1,6 +1,0 @@
-PG_HOST: 192.168.1.51
-PG_PORT: 5433
-PG_NAME: citydb-full_lyon-2012
-PG_USER: postgres
-PG_PASSWORD: postgres
-PG_VINTAGE: 2012

--- a/Computations/3DTiles/LyonTemporal/PythonCallingDocker/DBConfig2015.yml
+++ b/Computations/3DTiles/LyonTemporal/PythonCallingDocker/DBConfig2015.yml
@@ -1,6 +1,0 @@
-PG_HOST: 192.168.1.51
-PG_PORT: 5434
-PG_NAME: citydb-full_lyon-2015
-PG_USER: postgres
-PG_PASSWORD: postgres
-PG_VINTAGE: 2015

--- a/Computations/3DTiles/LyonTemporal/PythonCallingDocker/Readme.md
+++ b/Computations/3DTiles/LyonTemporal/PythonCallingDocker/Readme.md
@@ -54,13 +54,6 @@ The resulting file hierarchy will be located in the `junk` sub-directory.
    ```
 
 ## Issues
-### Convert the configuration files to YAML
-Merge the three configuration files in a single one using a YAML syntax.
-Extract the loading of that file (Docker3DCityDBServer::load_config_file)
-from the Docker3DCityDBServer class and pass the loaded dictionnary to
-the Docker3DCityDBServer::__init__ constructor.
-This will facilitate the Airflow/Prefect version that won't be able
-to use a configuration file but will be handled over parameters.
 
 ### Bug: extractBuildingDates stage fails on Villeurbanne data
 The following run fails

--- a/Computations/3DTiles/LyonTemporal/PythonCallingDocker/Readme.md
+++ b/Computations/3DTiles/LyonTemporal/PythonCallingDocker/Readme.md
@@ -2,7 +2,11 @@
  - [install Python3.7](https://www.python.org/)
 
 ## Configuration step
-Configure the three database configuration files `DBConfig[2009|2012|2015].yml`.
+Configure the `demo_configuration.py` file with the output_directory, the
+vintages (currently only 2009, 2012 and 2015 are available for the Grand Lyon) 
+and the borough you want to include (e.g. LYON_1ER, VILLEURBANNE, etc.). You
+must also provide one database configuration per vintage (these databases
+hold the citygml data). 
 
 Notes:
  * in order to configure `PG_HOST` i.e. the IP number of the host machine, you

--- a/Computations/3DTiles/LyonTemporal/PythonCallingDocker/Tests/test_docker_3dcitydb_server.py
+++ b/Computations/3DTiles/LyonTemporal/PythonCallingDocker/Tests/test_docker_3dcitydb_server.py
@@ -1,7 +1,7 @@
 import sys
-import os
 import logging
 import time
+import os
 import pytest
 
 sys.path.insert(0, '.')
@@ -23,17 +23,44 @@ class TestDocker3DCityDBServer:
     def test_docker_3dcitydb_server_lyon_1er_2009_2012(self):
         self.shared()
 
-        vintages = ['2009', '2012']
+        # This test may be launched alone. We need to make sure the output
+        # directory has been created.
+        pytest_output_path = os.path.join(os.getcwd(), 'pytest_outputs')
+        if not os.path.isdir(pytest_output_path):
+            os.mkdir(pytest_output_path)
+        # Create another directory in pytest_outputs for the postgres-data
+        postgres_output_path = os.path.join(pytest_output_path,
+                                            'postgres-data')
+        if not os.path.isdir(postgres_output_path):
+            os.mkdir(postgres_output_path)
+
+        vintages = [2009, 2012]
+        # FIXME: we should probably have a test_configuration.py (similarly
+        #  to demo_configuration.py) for that...
+        databases_config = {
+            2009: {
+                'PG_HOST': '192.168.1.51',
+                'PG_PORT': '5432',
+                'PG_NAME': 'citydb-full_lyon-2009',
+                'PG_USER': 'postgres',
+                'PG_PASSWORD': 'postgres'
+            },
+            2012: {
+                'PG_HOST': '192.168.1.51',
+                'PG_PORT': '5433',
+                'PG_NAME': 'citydb-full_lyon-2012',
+                'PG_USER': 'postgres',
+                'PG_PASSWORD': 'postgres'
+            }
+        }
 
         for vintage in vintages:
-            container = Docker3DCityDBServer()
-            configuration_file = 'DBConfig' + vintage + '.yml'
-            if not os.path.isfile(configuration_file):
-                logging.info(
-                    f'Missing configuration file {configuration_file}.')
-
-            container.set_config_file(configuration_file)
-            container.load_config_file()
+            container = Docker3DCityDBServer(vintage, databases_config[vintage])
+            absolute_path_output_dir = os.path.join(postgres_output_path,
+                                                    container.container_name)
+            if not os.path.isdir(absolute_path_output_dir):
+                os.mkdir(absolute_path_output_dir)
+            container.set_mounted_output_directory(absolute_path_output_dir)
             container.run()
 
             logging.info('Sleeping for 10 seconds for container to spin up.')

--- a/Computations/3DTiles/LyonTemporal/PythonCallingDocker/demo_configuration.py
+++ b/Computations/3DTiles/LyonTemporal/PythonCallingDocker/demo_configuration.py
@@ -11,3 +11,26 @@ boroughs = [
             'LYON_8EME',
             'LYON_9EME'
 ]
+databases = {
+    2009: {
+        'PG_HOST': '192.168.1.51',
+        'PG_PORT': '5432',
+        'PG_NAME': 'citydb-full_lyon-2009',
+        'PG_USER': 'postgres',
+        'PG_PASSWORD': 'postgres'
+    },
+    2012: {
+        'PG_HOST': '192.168.1.51',
+        'PG_PORT': '5433',
+        'PG_NAME': 'citydb-full_lyon-2012',
+        'PG_USER': 'postgres',
+        'PG_PASSWORD': 'postgres'
+    },
+    2015: {
+        'PG_HOST': '192.168.1.51',
+        'PG_PORT': '5434',
+        'PG_NAME': 'citydb-full_lyon-2015',
+        'PG_USER': 'postgres',
+        'PG_PASSWORD': 'postgres'
+    }
+}

--- a/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_helper.py
+++ b/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_helper.py
@@ -125,6 +125,9 @@ class DockerHelperContainer(DockerHelperBase):
             sys.exit(1)
         self.mounted_output_dir = directory
 
+    def get_mounted_output_directory(self):
+        return self.mounted_output_dir
+
     def get_container(self):
         if not self.__container:
             logging.info('Warning: requesting an unset container.')

--- a/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_load_3dcitydb.py
+++ b/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_load_3dcitydb.py
@@ -1,10 +1,9 @@
 import os
 import sys
 import logging
-import git
+import jinja2
 from docker_helper import DockerHelperBuild, DockerHelperTask
 from docker_3dcitydb_server import Docker3DCityDBServer
-import demo_strip_attributes
 import demo_configuration as demo
 
 
@@ -106,6 +105,23 @@ def import_files(config_file, input_filenames):
     d.run()
 
 
+def generate_configuration_file(j2_template_file, db_config, output_filename):
+    if not os.path.isfile(j2_template_file):
+        logging.info(f'Jinja2 template file {j2_template_file} '
+                     f'not found. Exiting')
+        sys.exit(1)
+    template_loader = jinja2.FileSystemLoader(searchpath="./")
+    template_env = jinja2.Environment(loader=template_loader)
+    template = template_env.get_template(j2_template_file)
+    template_stream = template.stream(PG_HOST=db_config['PG_HOST'],
+                                      PG_PORT=db_config['PG_PORT'],
+                                      PG_NAME=db_config['PG_NAME'],
+                                      PG_USER=db_config['PG_USER'],
+                                      PG_PASSWORD=db_config['PG_PASSWORD'])
+
+    template_stream.dump(output_filename)
+
+
 if __name__ == '__main__':
 
     logger = logging.getLogger(__name__)
@@ -117,37 +133,51 @@ if __name__ == '__main__':
 
     logging.info('Stage 1: starting databases.')
 
-    active_databases = list()
     for vintage in demo.vintages:
-        data_base = Docker3DCityDBServer()
-        data_base.set_config_file('DBConfig' + str(vintage) + '.yml')
-        data_base.load_config_file()
-        data_base.run()
-        active_databases.append(data_base)
-    logging.info('Stage 1: done.')
+        if not demo.databases:
+            logging.info(f'Databases configurations not found. Exiting')
+            sys.exit(1)
+        if not demo.databases[vintage]:
+            logging.info(f'Database configuration for vintage {vintage} not '
+                         f'found. You must specify one database configuration '
+                         f'per vintage. Exiting')
+            sys.exit(1)
+        out_db_config_filename = '3dCityDBImpExpConfig' + str(vintage) + '.xml'
+        generate_configuration_file('3dCityDBImpExpConfig.j2',
+                                    demo.databases[vintage],
+                                    out_db_config_filename)
 
-    logging.info(f'Stage 2: importing files to databases.')
-    for vintage in demo.vintages:
-        inputs = list()
-        # FIXME: the usage of StripInputsOutputs has been removed from now
-        #  until the fixmes of this class are resolved
-        for borough in demo.boroughs:
-            relative_output_dir = borough + '_' + str(vintage)
-            filename = borough + '_BATI_' + str(vintage) + \
-                '_splited_stripped.gml'
-            filepath = os.path.join(demo.output_dir, relative_output_dir,
-                                    filename)
-            inputs.append(os.path.abspath(filepath))
-
-        configuration_file = '3dCityDBImpExpConfig-' + str(vintage) + '.xml'
-        logging.info(f'Importation for vintage {str(vintage)}: starting.')
-        logging.info(f'Files set for importation: {inputs}')
-        import_files(os.path.abspath(configuration_file), inputs)
-        logging.info(f'Importation for vintage {str(vintage)}: done.')
-    logging.info('Stage 2: done')
-
-    logging.info('Stage 3: halting containers.')
-    for server in active_databases:
-        logging.info(f'   Halting container {server.get_container().name}.')
-        server.halt_service()
-    logging.info('Stage 3: done')
+    # active_databases = list()
+    # for vintage in demo.vintages:
+    #     data_base = Docker3DCityDBServer()
+    #     data_base.set_config_file('DBConfig' + str(vintage) + '.yml')
+    #     data_base.load_config_file()
+    #     data_base.run()
+    #     active_databases.append(data_base)
+    # logging.info('Stage 1: done.')
+    #
+    # logging.info(f'Stage 2: importing files to databases.')
+    # for vintage in demo.vintages:
+    #     inputs = list()
+    #     # FIXME: the usage of StripInputsOutputs has been removed from now
+    #     #  until the fixmes of this class are resolved
+    #     for borough in demo.boroughs:
+    #         relative_output_dir = borough + '_' + str(vintage)
+    #         filename = borough + '_BATI_' + str(vintage) + \
+    #             '_splited_stripped.gml'
+    #         filepath = os.path.join(demo.output_dir, relative_output_dir,
+    #                                 filename)
+    #         inputs.append(os.path.abspath(filepath))
+    #
+    #     configuration_file = '3dCityDBImpExpConfig-' + str(vintage) + '.xml'
+    #     logging.info(f'Importation for vintage {str(vintage)}: starting.')
+    #     logging.info(f'Files set for importation: {inputs}')
+    #     import_files(os.path.abspath(configuration_file), inputs)
+    #     logging.info(f'Importation for vintage {str(vintage)}: done.')
+    # logging.info('Stage 2: done')
+    #
+    # logging.info('Stage 3: halting containers.')
+    # for server in active_databases:
+    #     logging.info(f'   Halting container {server.get_container().name}.')
+    #     server.halt_service()
+    # logging.info('Stage 3: done')

--- a/Computations/3DTiles/LyonTemporal/PythonCallingDocker/requirements.txt
+++ b/Computations/3DTiles/LyonTemporal/PythonCallingDocker/requirements.txt
@@ -2,6 +2,5 @@ Jinja2
 docker
 wget
 patch
-pyyaml
 gitpython
 


### PR DESCRIPTION
* Generate 3DCityDB importer exporter config files with jinja2
* Move the content of the yml config files (DBConfig-<vintage>.yml) into demo_configuration.py
* Update docker 3dcitydb server test