### PR TITLE
Update3d citydb version

### DIFF
--- a/Computations/3DTiles/LyonTemporal/PythonCallingDocker/DemoTemporal/demo_load_3dcitydb_temporal.py
+++ b/Computations/3DTiles/LyonTemporal/PythonCallingDocker/DemoTemporal/demo_load_3dcitydb_temporal.py
@@ -25,13 +25,15 @@ class DemoLoad3DCityDBTemporal(DemoWithDataBasesTemporal):
         self.create_output_dir()   # Just making sure
 
         for vintage in self.vintages:
+            
+            
             logging.info(f'Importation for vintage {str(vintage)}: starting.')
             d = DockerLoad3DCityDB(self.databases[vintage])
-
+            
             inputs = list(map(os.path.abspath, input.get_vintage_resulting_filenames(vintage)))
             d.set_files_to_import(inputs)
             logging.info(f'Files set for importation: {inputs}')
-
+            
             d.run()
             d.check_log_result(log_filename)
             logging.info(f'Importation for vintage {str(vintage)}: done.')

--- a/Computations/3DTiles/LyonTemporal/PythonCallingDocker/DemoTemporal/demo_load_3dcitydb_temporal.py
+++ b/Computations/3DTiles/LyonTemporal/PythonCallingDocker/DemoTemporal/demo_load_3dcitydb_temporal.py
@@ -25,8 +25,6 @@ class DemoLoad3DCityDBTemporal(DemoWithDataBasesTemporal):
         self.create_output_dir()   # Just making sure
 
         for vintage in self.vintages:
-            
-            
             logging.info(f'Importation for vintage {str(vintage)}: starting.')
             d = DockerLoad3DCityDB(self.databases[vintage])
             

--- a/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_helper.py
+++ b/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_helper.py
@@ -14,7 +14,7 @@ class DockerHelperBase(ABC):
     def __init__(self, image_name, tag):
         """
         :param image_name: image name (e.g. "3DCityDB")
-        :param tag: tag of the image (e.g. "v4.0.2")
+        :param tag: tag of the image (e.g. "v4.3.0")
         """
         # Some methods of docker SDK need the image_name and/or the tag_name
         # independently while others need the full image name which is a
@@ -167,8 +167,9 @@ class DockerHelperContainer(DockerHelperBase):
         Other arguments can be set by child classes, e.g. the
         DockerHelperService class sets the 'ports' argument.
         """
+
         self.run_arguments = dict(
-            # command=["/bin/sh", "-c", "ls /Input /Output"],      # for debug
+            #command=["/bin/sh", "-c", "ls /Input /Output"],      # for debug
             command=self.get_command(),
             volumes=self.volumes,
             working_dir=self.working_dir,
@@ -201,6 +202,8 @@ class DockerHelperContainer(DockerHelperBase):
         Prepare the information required to launch the container and run it
         (always in a detached mode, for technical reasons).
         """
+        
+        
         self.__container = self.client.containers.run(
             self.full_image_name,
             **self.run_arguments)

--- a/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_helper.py
+++ b/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_helper.py
@@ -202,8 +202,6 @@ class DockerHelperContainer(DockerHelperBase):
         Prepare the information required to launch the container and run it
         (always in a detached mode, for technical reasons).
         """
-        
-        
         self.__container = self.client.containers.run(
             self.full_image_name,
             **self.run_arguments)

--- a/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_load_3dcitydb.py
+++ b/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_load_3dcitydb.py
@@ -2,76 +2,47 @@ import os
 import sys
 import logging
 import jinja2
-from docker_helper import DockerHelperBuild, DockerHelperTask
+from docker_helper import DockerHelperPull, DockerHelperTask
 
 
-class DockerLoad3DCityDB(DockerHelperBuild, DockerHelperTask):
+class DockerLoad3DCityDB(DockerHelperPull, DockerHelperTask):
 
     def __init__(self, db_config):
-        super().__init__('tumgis/3dcitydb-impexp', '4.2.3')
-
-        context_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                                   '..',
-                                   'Docker',
-                                   '3DCityDBImpExp-DockerContext')
-        self.build(context_dir)
-
-        self.configuration_filename = None
-        self.configuration_dir = None
-        self.__init__configuration_file(db_config)
-
+        super().__init__('3dcitydb/impexp', '4.3.0')
+        
+        # Variables
+        self.command = None
         self.files_to_import = list()
         self.importation_dir = None
 
-    def __init__configuration_file(self, db_config):
+        # Methods
+        self.pull()
+        self.__init__comand__line(db_config)
+
+
+    def __init__comand__line(self, db_config):
         """
         The 3dCityDB-importer requires a configuration with an ad-hoc (xml format) 
         file that must be generated out of the demo_configuration file.  
         """
-        # ### First generate the ad-hoc (xml format) configuration file expected by the 
-        # container
-        this_file_dir = os.path.dirname(os.path.realpath(__file__))
-        # j2_template_file = os.path.join(this_file_dir, '3dCityDBImpExpConfig.j2')
-        j2_template_file = '3dCityDBImpExpConfig.j2'
-
-        if not os.path.isfile(os.path.join(this_file_dir, j2_template_file)):
-            logging.info(f'Jinja2 template file {j2_template_file} not found. Exiting')
+        
+         # Check that db configuration is well defined
+        if (('PG_HOST' not in db_config)
+                or ('PG_USER' not in db_config)
+                or ('PG_PORT' not in db_config)
+                or ('PG_NAME' not in db_config)
+                or ('PG_USER' not in db_config)
+                or ('PG_PASSWORD' not in db_config)):
+            logging.error('Database is not properly defined in ' +
+                          self.config_file + ', please refer to README.md')
             sys.exit(1)
 
-        # Load template from file system
-        template_loader = jinja2.FileSystemLoader(searchpath=[this_file_dir])
-        template_env = jinja2.Environment(loader=template_loader)
-        template = template_env.get_template(j2_template_file)
-
-        # Create a TemplateStream object (that can be dumped into a file
-        # afterwards) and replace the variables with the values from db_config
-        template_stream = template.stream(PG_HOST=db_config['PG_HOST'],
-                                          PG_PORT=db_config['PG_PORT'],
-                                          PG_NAME=db_config['PG_NAME'],
-                                          PG_USER=db_config['PG_USER'],
-                                          PG_PASSWORD=db_config['PG_PASSWORD'])
-        # We need to refert to the configuration file through its absolute pathname
-        # so that we can mount the directory to the container
-        configuration_filename = os.path.abspath(
-            '3dCityDBImpExpConfig-' + db_config['PG_NAME'] + '.xml')
-        template_stream.dump(configuration_filename)
-
-        # Assert the file was properly generated: 
-        if not os.path.isfile(configuration_filename):
-            logging.info(f'Configuration file {configuration_filename} '
-                         f'not found. Exiting')
-            sys.exit(1)
-        # Just being paranoid: assert this is indeed an absolute pathname
-        if not os.path.isabs(configuration_filename):
-            logging.info(f'Configuration filename {configuration_filename} '
-                         f'is not absolute. Exiting')
-            sys.exit(1)
-
-        # ### Preparere the information for the container to mount the directory
-        # holding the configuration file and know about its configuratin filename
-        self.configuration_filename = os.path.basename(configuration_filename)
-        self.configuration_dir = os.path.dirname(configuration_filename)
-        self.add_volume(self.configuration_dir, '/InputConfig', 'rw')
+        self.command = 'import '
+        self.command += '-H ' + db_config['PG_HOST'] + ' '
+        self.command += '-d ' + db_config['PG_NAME'] + ' '
+        self.command += '-u ' + db_config['PG_USER'] + ' '
+        self.command += '-p ' + db_config['PG_PASSWORD'] + ' '
+        self.command += '-P ' + db_config['PG_PORT']
 
     def set_files_to_import(self, files):
         if not type(files) is list:
@@ -98,14 +69,14 @@ class DockerLoad3DCityDB(DockerHelperBuild, DockerHelperTask):
         self.add_volume(self.importation_dir, '/InputFiles', 'rw')
 
     def get_command(self):
-        command = '-config '  # Mind the trailing separator
-        command += '/InputConfig/' + self.configuration_filename + ' '
+        if not self.command:
+            logging.error('Importer/exporter : Imorter command line is NULL ')
+            sys.exit(1)
 
-        command += '-import '
         for file in self.files_to_import:
-            command += '/InputFiles/' + file + ';'
-
-        return command
+            self.command += ' /InputFiles/' + file + ' '
+        
+        return self.command
 
     def check_log_result(self, log_filename):
         """

--- a/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_load_3dcitydb.py
+++ b/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_load_3dcitydb.py
@@ -22,8 +22,7 @@ class DockerLoad3DCityDB(DockerHelperPull, DockerHelperTask):
 
     def __init__comand__line(self, db_config):
         """
-        The 3dCityDB-importer requires a configuration with an ad-hoc (xml format) 
-        file that must be generated out of the demo_configuration file.  
+        The 3dCityDB-importer need a specific command line to import data in 3dcitydb.  
         """
         
          # Check that db configuration is well defined

--- a/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_load_3dcitydb.py
+++ b/Computations/3DTiles/LyonTemporal/PythonCallingDocker/docker_load_3dcitydb.py
@@ -70,12 +70,11 @@ class DockerLoad3DCityDB(DockerHelperPull, DockerHelperTask):
 
     def get_command(self):
         if not self.command:
-            logging.error('Importer/exporter : Imorter command line is NULL ')
+            logging.error('Importer/exporter : Importer command line is NULL ')
             sys.exit(1)
-
         for file in self.files_to_import:
             self.command += ' /InputFiles/' + file + ' '
-        
+        logging.info('Command launch : ' + self.command)
         return self.command
 
     def check_log_result(self, log_filename):


### PR DESCRIPTION
Computation of Temporal & Static tilers are no tavailable with the new version of 3dcitydb importer exporter.
4.0.2 -> 4.3.0 [Link to the doc](https://3dcitydb-docs.readthedocs.io/en/release-v4.3.0/impexp/docker.html)
- [x]  Remove configuration files for importer
- [x] Write comand line to import data in database
- [x] Add some logs to have more feedbacks when data is import and failed process